### PR TITLE
[buck2][oss] Improve release process with version files

### DIFF
--- a/.github/actions/publish_tag/action.yml
+++ b/.github/actions/publish_tag/action.yml
@@ -26,6 +26,54 @@ runs:
       shell: bash
       run: |
         ls -R artifacts
+
+    - name: Consolidate version information
+      shell: bash
+      run: |
+        # Create a JSON file with consolidated version information
+        echo '{' > ${{github.workspace}}/consolidated_versions.json
+        echo '  "release_tag": "${{ inputs.tag }}",' >> ${{github.workspace}}/consolidated_versions.json
+        echo '  "generated_at": "'$(date -u +"%Y-%m-%dT%H:%M:%SZ")'",' >> ${{github.workspace}}/consolidated_versions.json
+        echo '  "platforms": [' >> ${{github.workspace}}/consolidated_versions.json
+
+        # Find all version_info.json files and consolidate them
+        FIRST=true
+        find ${{github.workspace}}/artifacts -name "version_info.json" | sort | while read version_file; do
+          if [ "$FIRST" = true ]; then
+            FIRST=false
+          else
+            echo ',' >> ${{github.workspace}}/consolidated_versions.json
+          fi
+          # Extract the content without the outer braces
+          cat "$version_file" | sed '1d;$d' | sed 's/^  /    /' >> ${{github.workspace}}/consolidated_versions.json
+        done
+
+        echo '  ]' >> ${{github.workspace}}/consolidated_versions.json
+        echo '}' >> ${{github.workspace}}/consolidated_versions.json
+
+        # Also create a human-readable markdown version for the release notes
+        echo "# Buck2 Version Information - Release ${{ inputs.tag }}" > ${{github.workspace}}/versions_summary.md
+        echo "Generated on $(date -u)" >> ${{github.workspace}}/versions_summary.md
+        echo "" >> ${{github.workspace}}/versions_summary.md
+        echo "## Version Information by Platform" >> ${{github.workspace}}/versions_summary.md
+        echo "" >> ${{github.workspace}}/versions_summary.md
+
+        # Find all version_info.json files and add them to the markdown
+        find ${{github.workspace}}/artifacts -name "version_info.json" | sort | while read version_file; do
+          platform=$(jq -r '.platform' "$version_file")
+          version=$(jq -r '.version_output' "$version_file")
+
+          echo "### Platform: $platform" >> ${{github.workspace}}/versions_summary.md
+          echo "" >> ${{github.workspace}}/versions_summary.md
+          echo '```' >> ${{github.workspace}}/versions_summary.md
+          echo "$version" >> ${{github.workspace}}/versions_summary.md
+          echo '```' >> ${{github.workspace}}/versions_summary.md
+          echo "" >> ${{github.workspace}}/versions_summary.md
+        done
+
+        # Copy the consolidated files to artifacts directory
+        cp ${{github.workspace}}/consolidated_versions.json ${{github.workspace}}/artifacts/
+        cp ${{github.workspace}}/versions_summary.md ${{github.workspace}}/artifacts/
     - uses: pyTooling/Actions/releaser@adef08d3bdef092282614f3b683897cefae82ee3 # v0.4.6
       id: upload_attempt_1
       with:
@@ -53,4 +101,12 @@ runs:
         # `${{ inputs.tag }}` Release Complete! :rocket:
         For the public download links of these build artifacts, please see:
           <https://github.com/$GITHUB_REPOSITORY/releases/tag/${{ inputs.tag }}>
+
+        ## Release Information
+        - Version information for all platforms is available in:
+          - JSON format: \`consolidated_versions.json\` (machine-readable)
+          - Markdown format: \`versions_summary.md\` (human-readable)
+        - SHA-256 hashes for all binaries are available in \`consolidated_hashes.md\` (if present)
+
+        Always verify the integrity of downloaded binaries before use.
         EOF

--- a/.github/workflows/upload_buck2.yml
+++ b/.github/workflows/upload_buck2.yml
@@ -122,6 +122,60 @@ jobs:
           mkdir artifacts
           zstd -z ${{ steps.set_variables.outputs.buck2_out }} -o ${{ steps.set_variables.outputs.buck2_zst }}
           zstd -z ${{ steps.set_variables.outputs.buck2_rust_project_out }} -o ${{ steps.set_variables.outputs.buck2_rust_project_zst }}
+
+      - name: Capture buck2 version information
+        shell: bash
+        run: |
+          # Create a JSON file with version information
+          mkdir -p artifacts
+
+          # Run buck2 --version and capture output
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            # Windows path
+            VERSION_OUTPUT=$("${{ steps.set_variables.outputs.buck2_out }}" --version 2>&1)
+          else
+            # Linux/macOS path
+            VERSION_OUTPUT=$("${{ steps.set_variables.outputs.buck2_out }}" --version 2>&1)
+          fi
+
+          # Create JSON file with version info
+          cat > artifacts/version_info.json << EOF
+          {
+            "platform": "${{ matrix.target.triple }}",
+            "build_date": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+            "version_output": $(echo "$VERSION_OUTPUT" | jq -R -s '.')
+          }
+          EOF
+
+      - name: Generate hashes for binaries
+        shell: bash
+        run: |
+          cd artifacts
+          echo "# Buck2 Binary Hashes" > hashes.md
+          echo "Generated on $(date -u)" >> hashes.md
+          echo "" >> hashes.md
+          echo "## SHA-256 Hashes" >> hashes.md
+          echo "" >> hashes.md
+          echo "| File | SHA-256 Hash |" >> hashes.md
+          echo "|------|-------------|" >> hashes.md
+
+          # Use different hash commands based on OS
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            # Windows uses CertUtil for hashing
+            for file in *.zst; do
+              # CertUtil outputs multiple lines, we need to extract just the hash
+              hash=$(certutil -hashfile "$file" SHA256 | grep -v "CertUtil" | grep -v "^$" | tr -d " \t\r\n")
+              echo "| $file | $hash |" >> hashes.md
+            done
+          else
+            # Linux and macOS use sha256sum
+            for file in *.zst; do
+              hash=$(sha256sum "$file" | awk '{print $1}')
+              echo "| $file | $hash |" >> hashes.md
+            done
+          fi
+          echo "" >> hashes.md
+
       - name: Upload
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Per https://github.com/facebook/buck2/issues/828

Gather all versions per architecture into a machine parseable and human readable sets of files.